### PR TITLE
Fix broken create association links

### DIFF
--- a/content/workflow/metadata_sciencebase_first.qmd
+++ b/content/workflow/metadata_sciencebase_first.qmd
@@ -75,8 +75,8 @@ section for options and instructions.
 ### 9. Create associations
 
 For projects and/or products, associations can be either [associated from a
-project](../project_records/associating_records_project.qmd) or [associated from
-a product](../product_records/associating_records_product.qmd).
+project](../project_records/associated_tab_project.qmd) or [associated from
+a product](../product_records/associated_tab_product.qmd).
 
 ### 10. Publish your records
 


### PR DESCRIPTION
Fix broken links on page https://usfws.github.io/Science_Applications_Metadata_Guidance/content/workflow/metadata_sciencebase_first.html#create-associations that reference creating associations in projects and products